### PR TITLE
Disable rubocop block length checks for all specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,9 +35,6 @@ Layout/LineLength:
 Lint/RedundantCopEnableDirective:
   Enabled: false
 
-Metrics/BlockLength:
-  IgnoredMethods: ['describe', 'context']
-
 Metrics/MethodLength:
   Max: 20
 

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,4 @@
+inherit_from: ../.rubocop.yml
+
+Metrics/BlockLength:
+  Enabled: false


### PR DESCRIPTION
The previous change did not fix the issue in ruby `2.3` which uses a different version of Rubocop.
