### PR TITLE
Add customer lookup request params validation

### DIFF
--- a/app/controllers/spree/api/v1/customers_controller.rb
+++ b/app/controllers/spree/api/v1/customers_controller.rb
@@ -52,7 +52,8 @@ module Spree
         end
 
         def validate_params
-          true # add custom validator
+          result = LookupValidator.new.call(params.permit!.to_h.deep_symbolize_keys)
+          render json: { errors: result.format_errors }, status: 422 unless result.success?
         end
       end
     end

--- a/app/validators/lookup_validator.rb
+++ b/app/validators/lookup_validator.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+class LookupValidator
+  def call(params)
+    errors = []
+
+    errors += validate_lookup_level(params)
+    errors += validate_unique_match_required(params)
+    errors += validate_query_emails(params)
+    errors += validate_query_phones(params)
+    errors += validate_query_name(params)
+    errors += validate_query_external_customer_id(params)
+
+    ValidationResult.new(errors)
+  end
+
+  private
+
+  def validate_lookup_level(params)
+    lookup_level = params[:lookupLevel]
+
+    return [%i[lookupLevel missing]] if lookup_level.nil?
+    return [%i[lookupLevel invalid]] unless lookup_level =~ /\A(?:basic|detailed)\Z/i
+
+    []
+  end
+
+  def validate_unique_match_required(params)
+    unique_match_required = params[:uniqueMatchRequired]
+
+    return [%i[uniqueMatchRequired missing]] if unique_match_required.nil?
+
+    if detailed_lookup?(params)
+      return [%i[uniqueMatchRequired not_true]] unless unique_match_required.in?([true, 'true'])
+    else
+      return [%i[uniqueMatchRequired invalid]] unless unique_match_required.in?([true, false, 'true', 'false'])
+    end
+
+    []
+  end
+
+  def validate_query_emails(params)
+    emails = params.dig(:query, :emails)
+
+    return [] if emails.nil? || string_or_array_of_strings?(emails)
+
+    [%i[query_emails invalid]]
+  end
+
+  def validate_query_phones(params)
+    phones = params.dig(:query, :phones)
+
+    return [] if phones.nil? || string_or_array_of_strings?(phones)
+
+    [%i[query_phones invalid]]
+  end
+
+  def validate_query_name(params)
+    name = params.dig(:query, :name)
+
+    return [] if name.nil? || nonempty_string?(name)
+
+    [%i[query_name invalid]]
+  end
+
+  def validate_query_external_customer_id(params)
+    id = params.dig(:query, :externalCustomerId)
+
+    return [%i[query_externalCustomerId missing]] if detailed_lookup?(params) && id.nil?
+    return [%i[query_externalCustomerId invalid]] if id.present? && !nonempty_string?(id)
+
+    []
+  end
+
+  def detailed_lookup?(params)
+    params[:lookupLevel] =~ /\Adetailed\Z/i
+  end
+
+  def nonempty_string?(value)
+    value.is_a?(String) && !value.empty?
+  end
+
+  def string_or_array_of_strings?(value)
+    return true if nonempty_string?(value)
+    return true if value.is_a?(Array) && value.all? { |v| nonempty_string?(v) }
+
+    false
+  end
+end

--- a/app/validators/validation_result.rb
+++ b/app/validators/validation_result.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ValidationResult
+  attr_reader :errors
+
+  def initialize(errors)
+    @errors = errors
+  end
+
+  def success?
+    errors.empty?
+  end
+
+  def format_errors
+    @errors.map do |error|
+      attr, code = error
+
+      {
+        attr: attr.to_s,
+        code: code.to_s,
+        detail: Spree.t("spree_gladly.errors.#{attr}.#{code}")
+      }
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,20 @@ en:
       signing_threshold: Signing Threshold
       signing_threshold_error: Signing Threshold should be empty, 0 or positive
       save_success: Updated Gladly configuration
+      errors:
+        lookupLevel:
+          missing: lookupLevel must be present
+          invalid: lookupLevel must be BASIC or DETAILED
+        uniqueMatchRequired:
+          missing: uniqueMatchRequired must be present
+          invalid: uniqueMatchRequired must be true or false
+          not_true: uniqueMatchRequired must be true for Detailed Lookup
+        query_emails:
+          invalid: query emails must be a nonempty string or an array of nonempty strings
+        query_phones:
+          invalid: query phones must be a nonempty string or an array of nonempty strings
+        query_name:
+          invalid: query name must be a nonempty string
+        query_externalCustomerId:
+          missing: query externalCustomerId must be present for Detailed Lookup
+          invalid: query externalCustomerId must be a nonempty string

--- a/spec/validators/lookup_validator_spec.rb
+++ b/spec/validators/lookup_validator_spec.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe LookupValidator do
+  subject { described_class.new.call(params) }
+
+  let(:lookup_level) { 'BASIC' }
+  let(:unique_match_required) { false }
+  let(:phones) { nil }
+  let(:emails) { nil }
+  let(:name) { nil }
+  let(:external_customer_id) { nil }
+
+  let(:params) do
+    {
+      lookupLevel: lookup_level,
+      uniqueMatchRequired: unique_match_required,
+      query: {
+        phones: phones,
+        emails: emails,
+        name: name,
+        externalCustomerId: external_customer_id
+      }.compact
+    }.compact
+  end
+
+  shared_examples 'valid' do
+    it 'valid' do
+      expect(subject.errors).to be_empty
+    end
+  end
+
+  shared_examples 'invalid' do |errors|
+    it 'invalid' do
+      res = subject
+      expect(res.errors).not_to be_empty
+      errors.each { |error| expect(res.errors).to include(error) }
+    end
+  end
+
+  context 'missing lookup level' do
+    let(:lookup_level) { nil }
+
+    include_examples 'invalid', [%i[lookupLevel missing]]
+  end
+
+  context 'invalid lookup level' do
+    let(:lookup_level) { 'FANCY' }
+
+    include_examples 'invalid', [%i[lookupLevel invalid]]
+  end
+
+  context 'basic lookup level' do
+    let(:lookup_level) { 'BASIC' }
+
+    include_examples 'valid'
+
+    context 'false uniqueMatchRequired' do
+      let(:unique_match_required) { false }
+
+      include_examples 'valid'
+    end
+
+    context 'missing externalCustomerId' do
+      let(:external_customer_id) { nil }
+
+      include_examples 'valid'
+    end
+  end
+
+  context 'detailed lookup level' do
+    let(:lookup_level) { 'DETAILED' }
+    let(:unique_match_required) { true }
+    let(:external_customer_id) { '123' }
+
+    include_examples 'valid'
+
+    context 'false uniqueMatchRequired' do
+      let(:unique_match_required) { false }
+
+      include_examples 'invalid', [%i[uniqueMatchRequired not_true]]
+    end
+
+    context 'missing externalCustomerId' do
+      let(:external_customer_id) { nil }
+
+      include_examples 'invalid', [%i[query_externalCustomerId missing]]
+    end
+
+    context 'invalid externalCustomerId' do
+      let(:external_customer_id) { 123 }
+
+      include_examples 'invalid', [%i[query_externalCustomerId invalid]]
+    end
+  end
+
+  context 'given valid emails' do
+    context 'string' do
+      let(:emails) { "email" }
+
+      include_examples 'valid'
+    end
+
+    context 'array of strings' do
+      let(:emails) { %w[foo bar baz] }
+
+      include_examples 'valid'
+    end
+  end
+
+  context 'given invalid emails' do
+    context 'empty string' do
+      let(:emails) { '' }
+
+      include_examples 'invalid', [%i[query_emails invalid]]
+    end
+
+    context 'integer' do
+      let(:emails) { 123 }
+
+      include_examples 'invalid', [%i[query_emails invalid]]
+    end
+
+    context 'invalid array 1' do
+      let(:emails) { ['foo', ''] }
+
+      include_examples 'invalid', [%i[query_emails invalid]]
+    end
+
+    context 'invalid array 2' do
+      let(:emails) { ['bar', 5] }
+
+      include_examples 'invalid', [%i[query_emails invalid]]
+    end
+  end
+
+  context 'given valid phones' do
+    context 'string' do
+      let(:phones) { "phone" }
+
+      include_examples 'valid'
+    end
+
+    context 'array of strings' do
+      let(:phones) { %w[foo bar baz] }
+
+      include_examples 'valid'
+    end
+  end
+
+  context 'given invalid phones' do
+    context 'empty string' do
+      let(:phones) { '' }
+
+      include_examples 'invalid', [%i[query_phones invalid]]
+    end
+
+    context 'integer' do
+      let(:phones) { 123 }
+
+      include_examples 'invalid', [%i[query_phones invalid]]
+    end
+
+    context 'invalid array 1' do
+      let(:phones) { ['foo', ''] }
+
+      include_examples 'invalid', [%i[query_phones invalid]]
+    end
+
+    context 'invalid array 2' do
+      let(:phones) { ['bar', 5] }
+
+      include_examples 'invalid', [%i[query_phones invalid]]
+    end
+  end
+
+  context 'given valid name' do
+    context 'absent' do
+      let(:name) { nil }
+
+      include_examples 'valid'
+    end
+
+    context 'string' do
+      let(:name) { 'James Bond' }
+
+      include_examples 'valid'
+    end
+  end
+
+  context 'given invalid name' do
+    context 'empty string' do
+      let(:name) { '' }
+
+      include_examples 'invalid', [%i[query_name invalid]]
+    end
+
+    context 'integer' do
+      let(:name) { 7 }
+
+      include_examples 'invalid', [%i[query_name invalid]]
+    end
+  end
+end

--- a/spec/validators/validation_result_spec.rb
+++ b/spec/validators/validation_result_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ValidationResult do
+  let(:subject) { described_class.new(errors) }
+
+  context('#format_errors') do
+    let(:errors) { [] }
+
+    context 'given no errors' do
+      it 'return empty array' do
+        expect(subject.format_errors).to eq []
+      end
+    end
+
+    context 'given errors' do
+      let(:errors) do
+        [
+          %i[lookupLevel missing],
+          %i[lookupLevel invalid],
+          %i[uniqueMatchRequired not_true],
+          %i[query_emails invalid],
+          %i[query_phones invalid],
+          %i[query_externalCustomerId missing]
+        ]
+      end
+
+      it 'return empty array' do
+        expected = [
+          { attr: 'lookupLevel', code: 'missing', detail: 'lookupLevel must be present' },
+          { attr: 'lookupLevel', code: 'invalid', detail: 'lookupLevel must be BASIC or DETAILED' },
+          { attr: 'uniqueMatchRequired', code: 'not_true',
+            detail: 'uniqueMatchRequired must be true for Detailed Lookup' },
+          { attr: 'query_emails', code: 'invalid',
+            detail: 'query emails must be a nonempty string or an array of nonempty strings' },
+          { attr: 'query_phones', code: 'invalid',
+            detail: 'query phones must be a nonempty string or an array of nonempty strings' },
+          { attr: 'query_externalCustomerId', code: 'missing',
+            detail: 'query externalCustomerId must be present for Detailed Lookup' }
+        ]
+
+        expect(subject.format_errors).to eq expected
+      end
+    end
+  end
+end


### PR DESCRIPTION
Validator for custom parameters is still missing, I want to add it later in a separate PR