### PR TITLE
Change transactions structure, add to_s

### DIFF
--- a/app/presenters/customer/basic_lookup_presenter.rb
+++ b/app/presenters/customer/basic_lookup_presenter.rb
@@ -18,9 +18,9 @@ module Customer
       resource.map do |user|
         {
           externalCustomerId: user.id.to_s,
-          name: address(user)&.full_name,
+          name: address(user)&.full_name.to_s,
           email: user.email,
-          phone: address(user)&.phone
+          phone: address(user)&.phone.to_s
         }
       end
     end

--- a/app/presenters/customer/detailed_lookup_presenter.rb
+++ b/app/presenters/customer/detailed_lookup_presenter.rb
@@ -31,14 +31,12 @@ module Customer
       resource.transactions.map do |transaction|
         {
           type: 'ORDER',
-          attributes: {
-            products: transaction_products(transaction: transaction),
-            orderLink: '',
-            note: transaction&.special_instructions,
-            orderTotal: transaction.total,
-            orderNumber: transaction.number,
-            createdAt: transaction.created_at
-          }
+          products: transaction_products(transaction: transaction),
+          orderLink: '',
+          note: transaction&.special_instructions.to_s,
+          orderTotal: transaction.total,
+          orderNumber: transaction.number,
+          createdAt: transaction.created_at
         }
       end
     end

--- a/spec/presenters/customer/detailed_lookup_presenter_spec.rb
+++ b/spec/presenters/customer/detailed_lookup_presenter_spec.rb
@@ -16,7 +16,8 @@ describe Customer::DetailedLookupPresenter, as: :presenter do
         # Todo add more specs after test against Gladly
         # rubocop:disable Layout/LineLength
         expect(results.first.keys).to eq %i[externalCustomerId name address emails phones transactions]
-        expect(results.first[:transactions][0][:attributes].keys).to eq %i[products orderLink note orderTotal orderNumber createdAt]
+        expect(results.first[:transactions][0].keys).to eq %i[type products orderLink note orderTotal orderNumber createdAt]
+        expect(results.first[:transactions][0][:products].first.keys).to eq %i[name status sku quantity total unitPrice]
         # rubocop:enable Layout/LineLength
       end
     end


### PR DESCRIPTION
This PR introducing changes for `transactions` payload structure, also add to some fields `to_s` to avoid `null` value in response