### PR TITLE
[PERFORMANCE] Don't do both lookups - we're only using 1

### DIFF
--- a/app/controllers/spree/api/v1/customers_controller.rb
+++ b/app/controllers/spree/api/v1/customers_controller.rb
@@ -25,19 +25,18 @@ module Spree
         private
 
         def serialize_collection(type:, collection:)
-          presenter = {
-            detailed: SpreeGladly::Config.detailed_lookup_presenter.new(resource: collection),
-            basic: SpreeGladly::Config.basic_lookup_presenter.new(resource: collection)
-          }[type]
+          klass     = type == :basic ? :basic_lookup_presenter : :detailed_lookup_presenter
+          presenter = SpreeGladly::Config.send(klass).send :new, resource: collection
 
           { results: presenter.to_h }
         end
 
         def customer_lookup(type:)
-          {
-            detailed: Customer::DetailedLookup.new(params: params),
-            basic: Customer::BasicLookup.new(params: params)
-          }[type]
+          if type == :basic
+            Customer::BasicLookup.new(params: params)
+          else
+            Customer::DetailedLookup.new(params: params)
+          end
         end
 
         def validate_signature


### PR DESCRIPTION
Right now, every API call to this endpoint does both the basic AND detailed lookup SQL queries..

Since the detailed lookup has started crippling our database after a postgres upgrade, let's only do detailed lookups if we really need to..